### PR TITLE
Rename "Create a simple exporter" -> "Create instrumented application"

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Summary is similar to histogram and calculates quantiles which can be configured
 
 [Source](https://www.youtube.com/watch?v=nJMRmhbY5hY)
 
-# Create a simple exporter
+# Create instrumented application
 
 We will create a request counter metric exporter using Go.
 


### PR DESCRIPTION
This isn't an exporter. In Prometheus terms an exporter is something that exports metrics from an 3rd party to prometheus: https://prometheus.io/docs/instrumenting/writing_exporters/#writing-exporters